### PR TITLE
Add back btn when on simulated results

### DIFF
--- a/open-source-election-game/package-lock.json
+++ b/open-source-election-game/package-lock.json
@@ -843,13 +843,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
-      "integrity": "sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
+      "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@eslint/core": "^0.10.0",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
+      "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2936,9 +2950,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {

--- a/open-source-election-game/src/editor/OsegSimulator.tsx
+++ b/open-source-election-game/src/editor/OsegSimulator.tsx
@@ -20,6 +20,7 @@ const numberOfSimulations = 500;
 function OsegSimulator(props: OsegSimulatorProps) {
   const [isSimulating, setIsSimulating] = useState(false);
   const [isShuffled, setIsShuffled] = useState(false);
+  const [showSimulatedResults, setShowSimulatedResults] = useState(false);
 
   const [allResults, setAllResults] = useState<FinalResultsModel[]>([]);
   const [allResultsIndex, setAllResultsIndex] = useState(0);
@@ -227,6 +228,7 @@ function OsegSimulator(props: OsegSimulatorProps) {
     setAllResults(allResultsRun);
     setAverageResult(averageResult);
     setHistogram(tempHistogram);
+    setShowSimulatedResults(true);
 
     const sortedResults = allResultsRun.sort((a, b) => {
       const apv = a.popularVotes.get(selectedCandidate) ?? 0;
@@ -240,6 +242,16 @@ function OsegSimulator(props: OsegSimulatorProps) {
     setBestResult(sortedResults[sortedResults.length - 1]);
     setWorstResult(sortedResults[0]);
     setIsSimulating(false);
+  }
+
+  const resetSimulation = () => {
+    setShowSimulatedResults(false);
+    setAllResults([]);
+    setAverageResult(null);
+    setBestResult(null);
+    setWorstResult(null);
+    setHistogram([]);
+    setAllResultsIndex(0);
   }
 
   if (isSimulating) {
@@ -257,89 +269,100 @@ function OsegSimulator(props: OsegSimulatorProps) {
 
   return (
     <div>
-      <label className="LabelText" htmlFor="candidate">
-        Candidate:{" "}
-      </label>
-      <select
-        id="candidate"
-        onChange={(e) => setSelectedCandidate(Number.parseInt(e.target.value))}
-      >
-        {getCandidatesWithSides().map((candidate) => {
-          return (
-            <option value={candidate.id} key={candidate.id}>
-              {candidate.firstName} {candidate.lastName}
-            </option>
-          );
-        })}
-      </select>
-      <label className="LabelText" htmlFor="runningMate">
-        Running Mate:{" "}
-      </label>
-      {getRunningMatesForCandidate(selectedCandidate).length > 0 && (
-        <select
-          id="runningMate"
-          onChange={(e) =>
-            setSelectedRunningMate(Number.parseInt(e.target.value))
-          }
-        >
-          {getRunningMatesForCandidate(selectedCandidate).map((candidate) => {
-            return (
-              <option value={candidate.id} key={candidate.id}>
-                {candidate.firstName + " " + candidate.lastName}
-              </option>
-            );
-          })}
-        </select>
-      )}
+      {!showSimulatedResults ? (
+        <>
+          <label className="LabelText" htmlFor="candidate">
+            Candidate:{" "}
+          </label>
+          <select
+            id="candidate"
+            onChange={(e) => setSelectedCandidate(Number.parseInt(e.target.value))}
+          >
+            {getCandidatesWithSides().map((candidate) => {
+              return (
+                <option value={candidate.id} key={candidate.id}>
+                  {candidate.firstName} {candidate.lastName}
+                </option>
+              );
+            })}
+          </select>
+          <label className="LabelText" htmlFor="runningMate">
+            Running Mate:{" "}
+          </label>
+          {getRunningMatesForCandidate(selectedCandidate).length > 0 && (
+            <select
+              id="runningMate"
+              onChange={(e) =>
+                setSelectedRunningMate(Number.parseInt(e.target.value))
+              }
+            >
+              {getRunningMatesForCandidate(selectedCandidate).map((candidate) => {
+                return (
+                  <option value={candidate.id} key={candidate.id}>
+                    {candidate.firstName + " " + candidate.lastName}
+                  </option>
+                );
+              })}
+            </select>
+          )}
 
-      {shouldShowShuffle && (
+          {shouldShowShuffle && (
+            <div>
+              <label>Shuffle Questions? </label>
+              <input
+                type="checkbox"
+                checked={isShuffled}
+                onChange={(e) => setIsShuffled(e.target.checked)}
+              ></input>
+            </div>
+          )}
+
+          <button onClick={() => simulateResults()}>
+            Simulate {numberOfSimulations} Times
+          </button>
+
+          <SimulatorAnswerPicker 
+            data={data} 
+            sideIndex={sideIndex} 
+            selectedAnswerIds={selectedAnswerIds} 
+            setSelectedAnswersId={setSelectedAnswerIds}
+          ></SimulatorAnswerPicker>
+        </>
+      ) : (
         <div>
-          <label>Shuffle Questions? </label>
-          <input
-            type="checkbox"
-            checked={isShuffled}
-            onChange={(e) => setIsShuffled(e.target.checked)}
-          ></input>
+          <button onClick={resetSimulation}>Back to Answer Picker</button>
+
+          {histogram.length > 0 && (
+            <div>
+              <h2>Histogram</h2>
+              <Histogram counts={histogram}></Histogram>
+            </div>
+          )}
+
+          {averageResult != null && (
+            <div>
+              <h2>Average Result</h2>
+              <FinalResults results={averageResult} theme={theme}></FinalResults>
+            </div>
+          )}
+
+          {bestResult != null && (
+            <div>
+              <h2>Best Result</h2>
+              <FinalResults results={bestResult} theme={theme}></FinalResults>
+            </div>
+          )}
+
+          {worstResult != null && (
+            <div>
+              <h2>Worst Result</h2>
+              <FinalResults results={worstResult} theme={theme}></FinalResults>
+            </div>
+          )}
+
+          {allResults.length > 0 && getAllResults()}
         </div>
       )}
-
-      <button onClick={() => simulateResults()}>
-        Simulate {numberOfSimulations} Times
-      </button>
-
-      {!averageResult && (
-        <SimulatorAnswerPicker data={data} sideIndex={sideIndex} selectedAnswerIds={selectedAnswerIds} setSelectedAnswersId={setSelectedAnswerIds}></SimulatorAnswerPicker>
-      )}
-
-      {histogram.length > 0 && (
-        <div>
-          <h2>Histogram</h2>
-          <Histogram counts={histogram}></Histogram>
-        </div>
-      )}
-
-      {averageResult != null && (
-        <div>
-          <h2>Average Result</h2>
-          <FinalResults results={averageResult} theme={theme}></FinalResults>
-        </div>
-      )}
-
-      {bestResult != null && (
-        <div>
-          <h2>Best Result</h2>
-          <FinalResults results={bestResult} theme={theme}></FinalResults>
-        </div>
-      )}
-
-      {worstResult != null && (
-        <div>
-          <h2>Worst Result</h2>
-          <FinalResults results={worstResult} theme={theme}></FinalResults>
-        </div>
-      )}
-
-      {allResults.length > 0 && getAllResults()}
     </div>
   );
 }


### PR DESCRIPTION
When someone is on the simulated results (the histograms, best result, etc), there is now a back button so they can go back to the answer picker. Does clear their previous locked in answers however.

Also did `npm audit fix` bc I had 2 vulnerabilities - uncertain if needed?